### PR TITLE
Add k9s to the rules_multitool setup

### DIFF
--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -20,6 +20,26 @@
       }
     ]
   },
+  "k9s": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "file": "k9s",
+        "url": "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Darwin_arm64.tar.gz",
+        "sha256": "68ff1541c60620466989019e86101805c1b6c70a746b1561261a403801f7fd48",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "file": "k9s",
+        "url": "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Linux_amd64.tar.gz",
+        "sha256": "0b697ed4aa80997f7de4deeed6f1fba73df191b28bf691b1f28d2f45fa2a9e9b",
+        "os": "linux",
+        "cpu": "x86_64"
+      }
+    ]
+  },
   "kubectl": {
     "binaries": [
       {


### PR DESCRIPTION
## Description
This adds k9s to the rules_mutlitool setup to pull in k9s version [0.50.18](https://github.com/derailed/k9s/releases/tag/v0.50.18).
